### PR TITLE
Uncomment download of missing datasets

### DIFF
--- a/dataset/init.lua
+++ b/dataset/init.lua
@@ -21,7 +21,7 @@ function dataset.get_data(name, url)
   check_and_mkdir(TORCH_DIR)
   check_and_mkdir(DATA_DIR)
   check_and_mkdir(dset_dir)
-  --check_and_download_file(data_path, url)
+  check_and_download_file(data_path, url)
 
   return data_path
 end


### PR DESCRIPTION
The line in charge of actually downloading the dataset has been commented out
in commit rosejn@71a40c6 : assuming this was accidental, I hereby propose to
uncomment it back.
