### PR TITLE
Reset cifar10.lua to its last working status

### DIFF
--- a/dataset/cifar10.lua
+++ b/dataset/cifar10.lua
@@ -7,37 +7,30 @@ require 'util/file'
 require 'logroll'
 require 'dataset'
 
-Cifar = {}
-Cifar.name         = 'cifar10',
-Cifar.dimensions   = {3, 32, 32},
-Cifar.n_dimensions = 3 * 32 * 32,
-Cifar.size         = function() return 50000 end,
-Cifar.classes      = {'airplane', 'automobile', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck'},
-Cifar.url          = 'http://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz',
-Cifar.dir          = 'cifar-10-batches-bin'
-Cifar.files        = {'cifar-10-batches-bin/data_batch_1.bin', 'cifar-10-batches-bin/data_batch_2.bin',
-                      'cifar-10-batches-bin/data_batch_3.bin', 'cifar-10-batches-bin/data_batch_4.bin',
-                      'cifar-10-batches-bin/data_batch_5.bin'},
-Cifar.batch_size   = 10000
-Cifar.test_file = {'cifar-10-batches-bin/test_batch.bin'}
+cifar10 = {}
 
-local function cifar_source(dir, pattern)
-    local data = torch.Tensor(unpack(Cifar.dimensions))
-    local files = pipe.matching_paths(dir, pattern)
-    local f = torch.DiskFile('data_batch_1.bin', 'r')
-    local class = f:readByte()
+cifar10_md = {
+    name         = 'cifar10',
+    dimensions   = {3, 32, 32},
+    n_dimensions = 3 * 32 * 32,
+    size         = function() return 50000 end,
 
-t7> img:storage():copy(f:readByte(3072))
+    classes      = {'airplane', 'automobile', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck'},
 
-end
+    url          = 'http://data.neuflow.org/data/cifar-10-torch.tar.gz',
 
-function Cifar.data_source()
-    local path = dataset.data_path(Cifar.name, Cifar.url, Cifar.dir)
-    return cifar_source(path, "
-end
+    files        = {'cifar-10-batches-t7/data_batch_1.t7', 'cifar-10-batches-t7/data_batch_2.t7',
+                    'cifar-10-batches-t7/data_batch_3.t7', 'cifar-10-batches-t7/data_batch_4.t7',
+                    'cifar-10-batches-t7/data_batch_5.t7'},
+    batch_size   = 10000
+}
 
-function Cifar.test_source()
-end
+
+cifar10_test_md = util.merge(util.copy(cifar10_md), {
+    size = function() return 10000 end,
+    files   = {'cifar-10-batches-t7/test_batch.t7'}
+})
+
 
 local function load_data_files(md)
     local data   = torch.Tensor(md.size(), md.n_dimensions)


### PR DESCRIPTION
The cifar10.lua file was last fully working in commit
rosejn@f9176ad4b50e01abcad20f88195f11e5855720c7 Later version did not run
(apparently left in middle of edition), hence this commit to restor the
version of cifar10.lua from rosejn@f9176ad4b5.
