### PR TITLE
Add option to binarize mnist

### DIFF
--- a/dataset/TableDataset.lua
+++ b/dataset/TableDataset.lua
@@ -6,7 +6,6 @@ require 'dataset/pipeline'
 require 'dataset/whitening'
 require 'pprint'
 
-
 local arg = util.arg
 
 local TableDataset = torch.class("dataset.TableDataset")
@@ -354,6 +353,22 @@ local function channels(...)
       end
    end
    return channels
+end
+
+
+-- Binarize the dataset: set to 0 any pixel strictly below the threshold, set to 1  those 
+-- above or equal to the threshold.
+--
+-- The argument specifies the threshold value for 0.
+function TableDataset:binarize(threshold)
+
+   local function binarize(x, threshold)
+       x[x:lt(threshold)] = 0;
+       x[x:ge(threshold)] = 1;
+       return x
+   end
+
+   binarize(self.dataset.data, threshold)
 end
 
 

--- a/dataset/mnist.lua
+++ b/dataset/mnist.lua
@@ -112,15 +112,20 @@ function Mnist.dataset(opts)
       samples, labels = dataset.sort_by_class(samples, labels)
    end
 
-   if binarize then
-      d:binarize(128)
-   end
-
    if (#scale == 2) then
       dataset.scale(samples, scale[1], scale[2])
    end
 
    local d = dataset.TableDataset({data = samples, class = labels}, Mnist)
+
+   if binarize then
+      if #scale == 2 then
+          threshold = (scale[2]+scale[1])/2
+      else 
+          threshold = 128
+      end
+      d:binarize(threshold)
+   end
 
    if normalize then
       d:normalize_globally()

--- a/dataset/mnist.lua
+++ b/dataset/mnist.lua
@@ -85,6 +85,7 @@ function Mnist.dataset(opts)
    test          = arg.optional(opts, 'test', false)
    scale         = arg.optional(opts, 'scale', {})
    normalize     = arg.optional(opts, 'normalize', false)
+   binarize     = arg.optional(opts, 'binarize', false)
    zca_whiten    = arg.optional(opts, 'zca_whiten', false)
    size          = arg.optional(opts, 'size', test and Mnist.test_size or Mnist.size)
    sort          = arg.optional(opts, 'sort', false)
@@ -98,6 +99,7 @@ function Mnist.dataset(opts)
    else
       data = Mnist.raw_data(size)
    end
+
    local samples = data:narrow(2, 1, Mnist.n_dimensions):clone()
    samples:resize(size, unpack(Mnist.dimensions))
 
@@ -108,6 +110,10 @@ function Mnist.dataset(opts)
 
    if sort then
       samples, labels = dataset.sort_by_class(samples, labels)
+   end
+
+   if binarize then
+      d:binarize(128)
    end
 
    if (#scale == 2) then

--- a/test/runner.lua
+++ b/test/runner.lua
@@ -1,6 +1,6 @@
 #!/usr/bin/env torch
 
-package.path = './?/init.lua;' .. package.path
+package.path = './?/init.lua;./?.lua;' .. package.path
 
 require 'paths'
 

--- a/test/test_table_dataset.lua
+++ b/test/test_table_dataset.lua
@@ -11,3 +11,17 @@ function tests.test_sampler()
     tester:assertTableEq(samples, {1,2,3,4,5}, "sample a dataset")
 end
 
+function tests.test_binarize()
+    local dset = {data = torch.Tensor({{1}, {2}, {3}, {4}, {5}})}
+    local td = dataset.TableDataset(dset)
+    local sampler = td:sampler()
+    local samples = seq.table(seq.map(function(s) return s.data[1] end, seq.take(5, sampler)))
+    table.sort(samples)
+    tester:assertTableEq(samples, {1,2,3,4,5}, "dataset wrong before binarization")
+
+    td:binarize(3)
+    sampler = td:sampler()
+    samples = seq.table(seq.map(function(s) return s.data[1] end, seq.take(5, sampler)))
+    table.sort(samples)
+    tester:assertTableEq(samples, {0,0,1,1,1}, "dataset wrong after binarization")
+end


### PR DESCRIPTION
Hi Jeff

This adds an option binarize (default to false) to Mnist, and a TableDataset:binarize() method, so as to run experiments on the binarized Mnist as done in several papers.
The new TableDataset:binarize() function mimics normalize_globally(). 

 The pipeline:binarize() available in pipe_line assumes continuous [0,1] pixels, whereas our  added TableDataset:binarize() allows any arbitrary threshold (128 is set for Mnist, following the litterature). Plus, pipeline is not documented ;-)

Thanks!
